### PR TITLE
fix: cache downstream images forever

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -232,6 +232,10 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Override response cache for future requests
+	resp.Header.Set("Cache-Control", "public")
+	resp.Header.Set("Expires", "Sat, 28 Dec 2199 00:00:00 GMT")
+
 	cached := resp.Header.Get(httpcache.XFromCache) == "1"
 	if p.Verbose {
 		p.logf("request: %+v (served from cache: %t)", *actualReq, cached)


### PR DESCRIPTION
Sets downstream response headers to keep images cached by the http client. This may or may not work depending on when the http cache round tripper determines caching should be done (if on close, this will work, but if on request, then it will not).